### PR TITLE
Fix the torch dependency markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "autoagora"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Alexis Asseman <alexis@semiotic.ai>",
     "Matt Deible <matt@semiotic.ai>",
@@ -31,9 +31,9 @@ aiohttp = "^3.8.1"
 gql = {extras = ["aiohttp"], version = "^3.2.0"}
 asyncpg = "^0.25.0"
 torch = [
-    {url="https://download.pytorch.org/whl/cpu/torch-1.11.0%2Bcpu-cp38-cp38-linux_x86_64.whl", platform="linux"},
-    {url="https://download.pytorch.org/whl/cpu/torch-1.10.0-cp38-none-macosx_10_9_x86_64.whl", platform="darwin", markers = "platform_machine == 'x86_64'"},
-    {url="https://download.pytorch.org/whl/cpu/torch-1.11.0-cp38-none-macosx_11_0_arm64.whl", platform="darwin", markers = "platform_machine == 'arm64'"}
+    {url="https://download.pytorch.org/whl/cpu/torch-1.11.0%2Bcpu-cp38-cp38-linux_x86_64.whl", markers = "sys_platform == 'linux' and platform_machine == 'x86_64'"},
+    {url="https://download.pytorch.org/whl/cpu/torch-1.10.0-cp38-none-macosx_10_9_x86_64.whl", markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'"},
+    {url="https://download.pytorch.org/whl/cpu/torch-1.11.0-cp38-none-macosx_11_0_arm64.whl", markers = "sys_platform == 'darwin' and platform_machine == 'arm64'"}
 ]
 anyio = "^3.5.0"
 numpy = "^1.22.3"


### PR DESCRIPTION
The previous fix broke the linux build... But I think we're getting closer to a solution.

Could @trigaten try it on his mac to see if it still works?

Sources:
- https://peps.python.org/pep-0496/
- https://peps.python.org/pep-0508/#environment-markers