### PR TITLE
Fix query count measurements

### DIFF
--- a/autoagora/subgraph_wrapper.py
+++ b/autoagora/subgraph_wrapper.py
@@ -29,13 +29,13 @@ class SubgraphWrapper:
             if time_since_last_change < SubgraphWrapper.GATEWAY_DELAY:
                 await sleep(SubgraphWrapper.GATEWAY_DELAY - time_since_last_change)
 
-        timestamp_1 = time()
         query_count_1 = await subgraph_query_count(self.subgraph)
+        timestamp_1 = time()
 
         await sleep(average_duration)
 
-        timestamp_2 = time()
         query_count_2 = await subgraph_query_count(self.subgraph)
+        timestamp_2 = time()
 
         queries_per_second = (query_count_2 - query_count_1) / (
             timestamp_2 - timestamp_1


### PR DESCRIPTION
Fixes #19 . (Or at least makes it much less likely to happen)

In #19 it seems that AA has trouble contacting `indexer-service`'s prometheus metrics endpoint. There is 2 fixes here that should make AA crashing much less likely:
- The timestamps between samples of a subgraph's query count were taken at the wrong time (before instead of after awaiting the data from the metrics).
- `subgraph_query_count`'s backoff now also catches any HTTP error. Needed the above is fixed, so that it is safe for `subgraph_query_count` to take an arbitrary amount of time, and not mess the Queries/s calculation.