### PR TITLE
feat: make qps observation duration configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ usage: autoagora [-h] --indexer-agent-mgmt-endpoint INDEXER_AGENT_MGMT_ENDPOINT 
                  INDEXER_SERVICE_METRICS_ENDPOINT --logs-postgres-host LOGS_POSTGRES_HOST
                  [--logs-postgres-port LOGS_POSTGRES_PORT] --logs-postgres-database LOGS_POSTGRES_DATABASE
                  --logs-postgres-username LOGS_POSTGRES_USERNAME --logs-postgres-password LOGS_POSTGRES_PASSWORD
-                 [--agora-models-refresh-interval AGORA_MODELS_REFRESH_INTERVAL] [--experimental-model-builder]
+                 [--agora-models-refresh-interval AGORA_MODELS_REFRESH_INTERVAL] 
+                 [--observation-duration OBSERVATION_DURATION] [--experimental-model-builder]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -72,6 +73,9 @@ optional arguments:
   --agora-models-refresh-interval AGORA_MODELS_REFRESH_INTERVAL
                         Interval in seconds between rebuilds of the Agora models. [env var:
                         AGORA_MODELS_REFRESH_INTERVAL] (default: 3600)
+  --observation-duration OBSERVATION_DURATION
+                        Duration of the measurement period of the query-per-second after a price multiplier update. 
+                        [env var: MEASUREMENT_PERIOD] (default: 60)                       
   --experimental-model-builder
                         Activates the relative query cost discovery. Otherwise only builds a default query pricing
                         model with automated market price discovery. [env var: EXPERIMENTAL_MODEL_BUILDER] (default:

--- a/autoagora/price_multiplier.py
+++ b/autoagora/price_multiplier.py
@@ -4,10 +4,22 @@
 import asyncio
 import logging
 
+import configargparse
 from autoagora_agents.agent_factory import AgentFactory
 from prometheus_client import Gauge
 
+from autoagora.config import args
 from autoagora.subgraph_wrapper import SubgraphWrapper
+
+argsparser = configargparse.get_argument_parser()
+argsparser.add_argument(
+    "--observation-duration",
+    env_var="MEASUREMENT_PERIOD",
+    required=False,
+    type=int,
+    default=60,
+    help="Duration of the measurement period of the query-per-second after a price multiplier update.",
+)
 
 reward_gauge = Gauge(
     "bandit_reward",
@@ -81,7 +93,9 @@ async def price_bandit_loop(subgraph: str):
 
             # 3. Get the reward.
             # Get queries per second.
-            queries_per_second = await environment.queries_per_second(60)
+            queries_per_second = await environment.queries_per_second(
+                args.observation_duration
+            )
             logging.debug(
                 "Price bandit %s - Queries per second: %s", subgraph, queries_per_second
             )


### PR DESCRIPTION
The query traffic pattern can be bursty for some subgraphs. Indexers may desire to set a longer time period in that case.