### PR TITLE
Refactor command line args

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,48 +45,66 @@ Therefore, only a single instance of `AutoAgora` should be running against an `i
 Configuration:
 
 ```txt
-usage: autoagora [-h] --indexer-agent-mgmt-endpoint INDEXER_AGENT_MGMT_ENDPOINT --indexer-service-metrics-endpoint
-                 INDEXER_SERVICE_METRICS_ENDPOINT --logs-postgres-host LOGS_POSTGRES_HOST
-                 [--logs-postgres-port LOGS_POSTGRES_PORT] --logs-postgres-database LOGS_POSTGRES_DATABASE
-                 --logs-postgres-username LOGS_POSTGRES_USERNAME --logs-postgres-password LOGS_POSTGRES_PASSWORD
-                 [--agora-models-refresh-interval AGORA_MODELS_REFRESH_INTERVAL] 
-                 [--observation-duration OBSERVATION_DURATION] [--experimental-model-builder] [--exclude-subgraphs]
+usage: autoagora [-h] [--experimental-model-builder]
+                 [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--json-logs JSON_LOGS]
+                 --indexer-agent-mgmt-endpoint INDEXER_AGENT_MGMT_ENDPOINT
+                 --indexer-service-metrics-endpoint INDEXER_SERVICE_METRICS_ENDPOINT
+                 [--observation-duration OBSERVATION_DURATION]
+                 [--exclude-subgraphs EXCLUDE_SUBGRAPHS]
+                 [--agora-models-refresh-interval AGORA_MODELS_REFRESH_INTERVAL]
+                 [--logs-postgres-host LOGS_POSTGRES_HOST]
+                 [--logs-postgres-port LOGS_POSTGRES_PORT]
+                 [--logs-postgres-database LOGS_POSTGRES_DATABASE]
+                 [--logs-postgres-username LOGS_POSTGRES_USERNAME]
+                 [--logs-postgres-password LOGS_POSTGRES_PASSWORD]
 
 optional arguments:
   -h, --help            show this help message and exit
-  --indexer-agent-mgmt-endpoint INDEXER_AGENT_MGMT_ENDPOINT
-                        URL to the indexer-agent management GraphQL endpoint. [env var: INDEXER_AGENT_MGMT_ENDPOINT]
-                        (default: None)
-  --indexer-service-metrics-endpoint INDEXER_SERVICE_METRICS_ENDPOINT
-                        HTTP endpoint for the indexer-service metrics. [env var: INDEXER_SERVICE_METRICS_ENDPOINT]
-                        (default: None)
-  --logs-postgres-host LOGS_POSTGRES_HOST
-                        Host of the postgres instance storing the logs. [env var: LOGS_POSTGRES_HOST] (default: None)
-  --logs-postgres-port LOGS_POSTGRES_PORT
-                        Port of the postgres instance storing the logs. [env var: LOGS_POSTGRES_PORT] (default: 5432)
-  --logs-postgres-database LOGS_POSTGRES_DATABASE
-                        Name of the logs database. [env var: LOGS_POSTGRES_DATABASE] (default: None)
-  --logs-postgres-username LOGS_POSTGRES_USERNAME
-                        Username for the logs database. [env var: LOGS_POSTGRES_USERNAME] (default: None)
-  --logs-postgres-password LOGS_POSTGRES_PASSWORD
-                        Password for the logs database. [env var: LOGS_POSTGRES_PASSWORD] (default: None)
-  --agora-models-refresh-interval AGORA_MODELS_REFRESH_INTERVAL
-                        Interval in seconds between rebuilds of the Agora models. [env var:
-                        AGORA_MODELS_REFRESH_INTERVAL] (default: 3600)
-  --observation-duration OBSERVATION_DURATION
-                        Duration of the measurement period of the query-per-second after a price multiplier update. 
-                        [env var: MEASUREMENT_PERIOD] (default: 60)                       
   --experimental-model-builder
-                        Activates the relative query cost discovery. Otherwise only builds a default query pricing
-                        model with automated market price discovery. [env var: EXPERIMENTAL_MODEL_BUILDER] (default:
-                        False)
-  --exclude-subgraphs
-                        Comma delimited list of subgraphs (ipfs hashes) to exclude from model updates. 
-                        [env var: EXCLUDE_SUBGRAPHS] (default: None)
+                        Activates the relative query cost discovery. Otherwise only builds a
+                        default query pricing model with automated market price discovery. [env
+                        var: EXPERIMENTAL_MODEL_BUILDER] (default: False)
   --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         [env var: LOG_LEVEL] (default: WARNING)
   --json-logs JSON_LOGS
-                        Output logs in JSON format. Compatible with GKE. [env var: JSON_LOGS] (default: False)
+                        Output logs in JSON format. Compatible with GKE. [env var: JSON_LOGS]
+                        (default: False)
+  --indexer-agent-mgmt-endpoint INDEXER_AGENT_MGMT_ENDPOINT
+                        URL to the indexer-agent management GraphQL endpoint. [env var:
+                        INDEXER_AGENT_MGMT_ENDPOINT] (default: None)
+  --indexer-service-metrics-endpoint INDEXER_SERVICE_METRICS_ENDPOINT
+                        HTTP endpoint for the indexer-service metrics. [env var:
+                        INDEXER_SERVICE_METRICS_ENDPOINT] (default: None)
+  --observation-duration OBSERVATION_DURATION
+                        Duration of the measurement period of the query-per-second after a price
+                        multiplier update. [env var: MEASUREMENT_PERIOD] (default: 60)
+
+Model Builder Options:
+
+  --exclude-subgraphs EXCLUDE_SUBGRAPHS
+                        Comma delimited list of subgraphs (ipfs hash) to exclude from model
+                        updates. [env var: EXCLUDE_SUBGRAPHS] (default: None)
+  --agora-models-refresh-interval AGORA_MODELS_REFRESH_INTERVAL
+                        Interval in seconds between rebuilds of the Agora models. [env var:
+                        AGORA_MODELS_REFRESH_INTERVAL] (default: 3600)
+  --logs-postgres-host LOGS_POSTGRES_HOST
+                        Host of the postgres instance storing the logs. [env var:
+                        LOGS_POSTGRES_HOST] (default: None)
+  --logs-postgres-port LOGS_POSTGRES_PORT
+                        Port of the postgres instance storing the logs. [env var:
+                        LOGS_POSTGRES_PORT] (default: 5432)
+  --logs-postgres-database LOGS_POSTGRES_DATABASE
+                        Name of the logs database. [env var: LOGS_POSTGRES_DATABASE] (default:
+                        None)
+  --logs-postgres-username LOGS_POSTGRES_USERNAME
+                        Username for the logs database. [env var: LOGS_POSTGRES_USERNAME]
+                        (default: None)
+  --logs-postgres-password LOGS_POSTGRES_PASSWORD
+                        Password for the logs database. [env var: LOGS_POSTGRES_PASSWORD]
+                        (default: None)
+
+ If an arg is specified in more than one place, then commandline values override environment
+variables which override defaults.
 ```
 
 AutoAgora also exposes metrics for Prometheus on port `8000` (Example values):

--- a/autoagora/config.py
+++ b/autoagora/config.py
@@ -1,6 +1,7 @@
 # Copyright 2022-, Semiotic AI, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 import logging
 from typing import Any, Optional, Sequence
 
@@ -20,13 +21,37 @@ args = _Args()
 def init_config(argv: Optional[Sequence[str]] = None):
     """Parses the arguments from the global argument parser and sets logging config.
 
-    To add arguments, simply add them to the global argument parser from any module, as
-    long as the modules are imported before the invocation of that function.
+    Add new arguments in this function.
 
     Argument values are added to the global `args` namespace object declared in this
     module.
     """
-    argsparser = configargparse.get_argument_parser()
+    # 2 arg parsers to make it possible to fetch the `experimental_model_builder` option
+    # early without breaking anything.
+    argsparser_experimental_model_builder = configargparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter, add_help=False
+    )
+    argsparser_experimental_model_builder.add_argument(
+        "--experimental-model-builder",
+        env_var="EXPERIMENTAL_MODEL_BUILDER",
+        action="store_true",
+        help="Activates the relative query cost discovery. Otherwise only builds a "
+        "default query pricing model with automated market price discovery.",
+    )
+    # Get the value of `experimental-model-builder` early
+    _, argv = argsparser_experimental_model_builder.parse_known_args(
+        argv, namespace=args
+    )
+
+    # 2nd arg parser
+    argsparser = configargparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        parents=[argsparser_experimental_model_builder],
+    )
+
+    #
+    # General arguments
+    #
     argsparser.add_argument(
         "--log-level",
         env_var="LOG_LEVEL",
@@ -43,8 +68,104 @@ def init_config(argv: Optional[Sequence[str]] = None):
         required=False,
         help="Output logs in JSON format. Compatible with GKE.",
     )
+
+    #
+    # Indexer utils
+    #
+    argsparser.add_argument(
+        "--indexer-agent-mgmt-endpoint",
+        env_var="INDEXER_AGENT_MGMT_ENDPOINT",
+        required=True,
+        help="URL to the indexer-agent management GraphQL endpoint.",
+    )
+
+    #
+    # Query volume metrics
+    #
+
+    argsparser.add_argument(
+        "--indexer-service-metrics-endpoint",
+        env_var="INDEXER_SERVICE_METRICS_ENDPOINT",
+        required=True,
+        help="HTTP endpoint for the indexer-service metrics.",
+    )
+
+    #
+    # Price multiplier (Absolute price)
+    #
+    argsparser.add_argument(
+        "--observation-duration",
+        env_var="MEASUREMENT_PERIOD",
+        required=False,
+        type=int,
+        default=60,
+        help="Duration of the measurement period of the query-per-second after a price "
+        "multiplier update.",
+    )
+
+    #
+    # Optional model builder (Relative query costs)
+    #
+    model_builder_group = argsparser.add_argument_group(
+        title="Model Builder Options", description=""
+    )
+    model_builder_group.add_argument(
+        "--exclude-subgraphs",
+        env_var="EXCLUDE_SUBGRAPHS",
+        required=False,
+        help="Comma delimited list of subgraphs (ipfs hash) to exclude from model "
+        "updates.",
+    )
+    model_builder_group.add_argument(
+        "--agora-models-refresh-interval",
+        env_var="AGORA_MODELS_REFRESH_INTERVAL",
+        required=False,
+        type=int,
+        default=3600,
+        help="Interval in seconds between rebuilds of the Agora models.",
+    )
+
+    #
+    # Logs DB
+    #
+
+    # Needed only if the model builder is turned on
+    model_builder_group.add_argument(
+        "--logs-postgres-host",
+        env_var="LOGS_POSTGRES_HOST",
+        required=args.experimental_model_builder,
+        help="Host of the postgres instance storing the logs.",
+    )
+    model_builder_group.add_argument(
+        "--logs-postgres-port",
+        env_var="LOGS_POSTGRES_PORT",
+        required=False,
+        type=int,
+        default=5432,
+        help="Port of the postgres instance storing the logs.",
+    )
+    model_builder_group.add_argument(
+        "--logs-postgres-database",
+        env_var="LOGS_POSTGRES_DATABASE",
+        required=args.experimental_model_builder,
+        help="Name of the logs database.",
+    )
+    model_builder_group.add_argument(
+        "--logs-postgres-username",
+        env_var="LOGS_POSTGRES_USERNAME",
+        required=args.experimental_model_builder,
+        help="Username for the logs database.",
+    )
+    model_builder_group.add_argument(
+        "--logs-postgres-password",
+        env_var="LOGS_POSTGRES_PASSWORD",
+        required=args.experimental_model_builder,
+        help="Password for the logs database.",
+    )
+
     argsparser.parse_args(args=argv, namespace=args)
 
+    # Set the logs formatting
     if args.json_logs:
         logHandler = logging.StreamHandler()
         formatter = jsonlogger.JsonFormatter(

--- a/autoagora/indexer_utils.py
+++ b/autoagora/indexer_utils.py
@@ -8,20 +8,11 @@ from typing import Any, Dict, Mapping, Optional, Set
 
 import aiohttp
 import backoff
-import configargparse
 from base58 import b58decode, b58encode
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 
 from autoagora.config import args
-
-argsparser = configargparse.get_argument_parser()
-argsparser.add_argument(
-    "--indexer-agent-mgmt-endpoint",
-    env_var="INDEXER_AGENT_MGMT_ENDPOINT",
-    required=True,
-    help="URL to the indexer-agent management GraphQL endpoint.",
-)
 
 
 def ipfs_hash_to_hex(ipfs_hash: str) -> str:

--- a/autoagora/logs_db.py
+++ b/autoagora/logs_db.py
@@ -7,43 +7,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 import asyncpg
-import configargparse
 
 from autoagora.config import args
-
-argsparser = configargparse.get_argument_parser()
-argsparser.add_argument(
-    "--logs-postgres-host",
-    env_var="LOGS_POSTGRES_HOST",
-    required=True,
-    help="Host of the postgres instance storing the logs.",
-)
-argsparser.add_argument(
-    "--logs-postgres-port",
-    env_var="LOGS_POSTGRES_PORT",
-    required=False,
-    type=int,
-    default=5432,
-    help="Port of the postgres instance storing the logs.",
-)
-argsparser.add_argument(
-    "--logs-postgres-database",
-    env_var="LOGS_POSTGRES_DATABASE",
-    required=True,
-    help="Name of the logs database.",
-)
-argsparser.add_argument(
-    "--logs-postgres-username",
-    env_var="LOGS_POSTGRES_USERNAME",
-    required=True,
-    help="Username for the logs database.",
-)
-argsparser.add_argument(
-    "--logs-postgres-password",
-    env_var="LOGS_POSTGRES_PASSWORD",
-    required=True,
-    help="Password for the logs database.",
-)
 
 
 class LogsDB:

--- a/autoagora/model_builder.py
+++ b/autoagora/model_builder.py
@@ -4,22 +4,11 @@
 import asyncio as aio
 import logging
 
-import configargparse
 import graphql
 
 from autoagora.config import args
 from autoagora.indexer_utils import set_cost_model
 from autoagora.logs_db import LogsDB
-
-argsparser = configargparse.get_argument_parser()
-argsparser.add_argument(
-    "--agora-models-refresh-interval",
-    env_var="AGORA_MODELS_REFRESH_INTERVAL",
-    required=False,
-    type=int,
-    default=3600,
-    help="Interval in seconds between rebuilds of the Agora models.",
-)
 
 
 async def model_builder(subgraph: str) -> str:

--- a/autoagora/price_multiplier.py
+++ b/autoagora/price_multiplier.py
@@ -4,22 +4,11 @@
 import asyncio
 import logging
 
-import configargparse
 from autoagora_agents.agent_factory import AgentFactory
 from prometheus_client import Gauge
 
 from autoagora.config import args
 from autoagora.subgraph_wrapper import SubgraphWrapper
-
-argsparser = configargparse.get_argument_parser()
-argsparser.add_argument(
-    "--observation-duration",
-    env_var="MEASUREMENT_PERIOD",
-    required=False,
-    type=int,
-    default=60,
-    help="Duration of the measurement period of the query-per-second after a price multiplier update.",
-)
 
 reward_gauge = Gauge(
     "bandit_reward",

--- a/autoagora/query_metrics.py
+++ b/autoagora/query_metrics.py
@@ -8,17 +8,8 @@ from typing import Dict
 
 import aiohttp
 import backoff
-import configargparse
 
 from autoagora.config import args
-
-argsparser = configargparse.get_argument_parser()
-argsparser.add_argument(
-    "--indexer-service-metrics-endpoint",
-    env_var="INDEXER_SERVICE_METRICS_ENDPOINT",
-    required=True,
-    help="HTTP endpoint for the indexer-service metrics.",
-)
 
 
 class HTTPError(Exception):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,91 @@
+import pytest
+
+from autoagora.config import args, init_config
+
+
+class TestConfigArgs:
+    """Testing the command line arguments handling.
+
+    Testing because there's some not so trivial stuff going on with the optional
+    `--experimental-model-builder`.
+    """
+
+    def test_model_builder_off(self):
+        indexer_mgmt_endpoint_value = "http://indexer-something:1234"
+        indexer_service_metrics_endpoint_value = "https://indexer-service:2345"
+
+        init_config(
+            [
+                "--indexer-agent-mgmt-endpoint",
+                indexer_mgmt_endpoint_value,
+                "--indexer-service-metrics-endpoint",
+                indexer_service_metrics_endpoint_value,
+            ]
+        )
+
+        # Expecting no errors as we've provided all mandatory arguments in the case
+        # where the `--experimental-model-builder` is not enabled
+
+        assert args.indexer_agent_mgmt_endpoint == indexer_mgmt_endpoint_value
+        assert (
+            args.indexer_service_metrics_endpoint
+            == indexer_service_metrics_endpoint_value
+        )
+
+    def test_model_builder_on_missing_args(self):
+        indexer_mgmt_endpoint_value = "http://indexer-something:1234"
+        indexer_service_metrics_endpoint_value = "https://indexer-service:2345"
+
+        # Expecting errors because enabling the `--experimental-model-builder` adds new
+        # mandatory arguments
+        with pytest.raises(SystemExit) as exit_error:
+            init_config(
+                [
+                    "--indexer-agent-mgmt-endpoint",
+                    indexer_mgmt_endpoint_value,
+                    "--indexer-service-metrics-endpoint",
+                    indexer_service_metrics_endpoint_value,
+                    "--experimental-model-builder",
+                ]
+            )
+
+        assert exit_error.value.code == 2
+
+    def test_model_builder_on(self):
+        # These are always mandatory
+        indexer_mgmt_endpoint_value = "http://indexer-something:1234"
+        indexer_service_metrics_endpoint_value = "https://indexer-service:2345"
+
+        # These are mandatory when `--experimental-model-builder` is on
+        logs_postgres_host_value = "pghost"
+        logs_postgres_database_value = "pgdatabase"
+        logs_postgres_username_value = "pguser"
+        logs_postgres_password_value = "pgpass"
+
+        init_config(
+            [
+                "--indexer-agent-mgmt-endpoint",
+                indexer_mgmt_endpoint_value,
+                "--indexer-service-metrics-endpoint",
+                indexer_service_metrics_endpoint_value,
+                "--experimental-model-builder",
+                "--logs-postgres-host",
+                logs_postgres_host_value,
+                "--logs-postgres-database",
+                logs_postgres_database_value,
+                "--logs-postgres-username",
+                logs_postgres_username_value,
+                "--logs-postgres-password",
+                logs_postgres_password_value,
+            ]
+        )
+
+        assert args.indexer_agent_mgmt_endpoint == indexer_mgmt_endpoint_value
+        assert (
+            args.indexer_service_metrics_endpoint
+            == indexer_service_metrics_endpoint_value
+        )
+        assert args.logs_postgres_host == logs_postgres_host_value
+        assert args.logs_postgres_database == logs_postgres_database_value
+        assert args.logs_postgres_username == logs_postgres_username_value
+        assert args.logs_postgres_password == logs_postgres_password_value


### PR DESCRIPTION
- Moved all arguments handling to `config.py`
  Improved the handling of the arguments that are mandatory when the `--experimental-model-builder` is turned on.
  Also fixed `--help` not showing all the arguments.
- Refreshed the AutoAgora help output in `README.md`