### PR TITLE
ci(semver.yml): updated semantic-release to provide published flag and published_version

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -44,7 +44,7 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: autoagora
-        tags: latest v${{ needs.release.outputs.published_version }}. v${{ needs.release.outputs.published_version }}
+        tags: latest v${{ needs.release.outputs.published_version }} v${{ needs.release.outputs.published_version }}
         containerfiles: |
           ./Dockerfile
     - name: Push

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -15,6 +15,9 @@ jobs:
     outputs:      
       published: ${{ steps.release.outputs.published }}
       published_version: ${{ steps.release.outputs.published_version }}
+      published_version_major: ${{ steps.release.outputs.published_version_major }}
+      published_version_minor: ${{ steps.release.outputs.published_version_minor }}
+      published_version_patch: ${{ steps.release.outputs.published_version_patch }}
 
     steps:
     - uses: actions/checkout@v3
@@ -44,7 +47,11 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: autoagora
-        tags: latest v${{ needs.release.outputs.published_version }} v${{ needs.release.outputs.published_version }}
+        tags: >
+          latest
+          v${{ needs.release.outputs.published_version_major }}
+          v${{ needs.release.outputs.published_version_major }}.${{ needs.release.outputs.published_version_minor }}
+          v${{ needs.release.outputs.published_version}}
         containerfiles: |
           ./Dockerfile
     - name: Push

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -12,32 +12,31 @@ jobs:
     permissions:
       contents: write
 
-    outputs:
-      new_release_published: ${{ steps.release.outputs.new_release_published }}
-      new_release_major_version: ${{ steps.release.outputs.new_release_major_version }}
-      new_release_minor_version: ${{ steps.release.outputs.new_release_minor_version }}
-      new_release_patch_version: ${{ steps.release.outputs.new_release_patch_version }}
+    outputs:      
+      published: ${{ steps.release.outputs.published }}
+      published_version: ${{ steps.release.outputs.published_version }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Python Semantic Release
       id: release
-      uses: aasseman/python-semantic-release@gh_outputs
+      uses: tumaysem/python-semantic-release@master
       with:
+        additional_options: --github
         github_token: ${{ secrets.GITHUB_TOKEN }}
   
   container_build:
     runs-on: ubuntu-latest
     needs: release
-    if: needs.release.outputs.new_release_published == 'true'
+    if: needs.release.outputs.published == 'True'
     permissions:
       packages: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Build Image
@@ -45,7 +44,7 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: autoagora
-        tags: latest v${{ needs.release.outputs.new_release_major_version }}.${{ needs.release.outputs.new_release_minor_version }}.${{ needs.release.outputs.new_release_patch_version }} v${{ needs.release.outputs.new_release_major_version }}.${{ needs.release.outputs.new_release_minor_version }} v${{ needs.release.outputs.new_release_major_version }}
+        tags: latest v${{ needs.release.outputs.published_version }}. v${{ needs.release.outputs.published_version }}
         containerfiles: |
           ./Dockerfile
     - name: Push


### PR DESCRIPTION
1. added exporting publish information to github actions output [python-semantic-release](https://github.com/python-semantic-release/python-semantic-release/commit/059f000a6059951da82e8271006fd8c2f4e39fe3)

2. updated semver.yml using published flag and published_version

Signed-off-by: Tumay Tuzcu <tumay@semiotic.ai>