### PR TITLE
build(Docker): Build whl w/ pip instead of poetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,10 @@ FROM python:3.8 as build
 ENV PYTHONUNBUFFERED=1
 WORKDIR /root
 
-RUN pip install poetry
-ENV PATH=/root/.local/bin:$PATH
+COPY . src/
 
-COPY . .
-
-RUN poetry config virtualenvs.create true && \
-    poetry build -f wheel -n
+RUN pip install --upgrade pip && \
+    pip wheel --no-deps --wheel-dir dist ./src
 
 FROM python:3.8-slim
 


### PR DESCRIPTION
Poetry was not setting the wheel version. Now the build is simpler and the
wheel version is set correctly.
Not a perfect solution though, as you always need the `.git/` directory for the correct version to be inferred.